### PR TITLE
chore: added a bug section to the READ.ME that solves the hydration error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ docker run -it --name pgsql-classroom -e POSTGRES_PASSWORD=password -d --restart
 8. Run `npm run create-mock-user-server` in a seperate terminal window.
 9. Run `npm run create-mock-authentication-server` in a seperate terminal window.
 
+## Bugs
+
+1. After setting everything up and running the development server,
+   if you get a hydration error it is due to a bug in React 18.
+   In order to fix this issue you need to downgrade the dependencies
+   to React 17. If you don't have this bug then you can ignore this.
+   `npm install --save react@17.0.2 react-dom@17.0.2`
+
 ### Join us in our [Discord Chat](https://discord.gg/qcynkd4Edx) here.
 
 ### License


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Description:
- There is a bug that installs the latest version of React causing the program to throw a [hydration error](https://nextjs.org/docs/messages/react-hydration-error). I figure out a way to avoid that bug by just downgraded to react 17, which is what the codebase was initially running on.
- I added a bug section in the READ.ME for now just in case other contributors are having the same issue. Maybe in the future it can be removed if we find the solution of why it's installing the latest version of react.