### PR TITLE
fix: A warning message of classes page

### DIFF
--- a/pages/classes/index.js
+++ b/pages/classes/index.js
@@ -97,10 +97,10 @@ export default function Classes({
           </div>
 
           {<Modal userId={user} certificationNames={certificationNames} />}
-          {classrooms.map(classrooms => (
-            <div key={classrooms.id}>
+          {classrooms.map(classroom => (
+            <div key={classroom.classroomId}>
               <ClassInviteTable
-                classes={classrooms}
+                classes={classroom}
                 certificationNames={certificationNames}
                 userId={user}
               ></ClassInviteTable>


### PR DESCRIPTION


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #175

<!-- Feel free to add any additional description of changes below this line -->

1. This warning showed because while the app is rendering an array classrooms using map function, it is using classroom.id as the key of each classroom. But there is no ‘id’ field in classroom schema. There is only ‘classroomId’ field. So I used ‘classroomId’ instead of ‘id’.
<img width="900" alt="Screen Shot 2022-11-01 at 3 47 17 PM" src="https://user-images.githubusercontent.com/90477208/199384105-bae955b3-63c9-4124-a0ee-912f6f63b5a8.png">


2. As the syntax in map function,  map((element) => { /* … */ }) , the element is the current element being processed in the array. It would be better to use classroom to refer to an element in the classrooms array.

