### PR TITLE
fix: two wranings of Navbar component

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -22,15 +22,11 @@ export default function Navbar({ children }) {
           </a>
         </Link>
         <div className='flex-1 inline-flex justify-end'>
-          {React.Children.toArray(children).length > 1 ? (
-            children.map(children => (
-              <div className='pl-2 hidden md:block' key={children}>
-                <p>{children}</p>
-              </div>
-            ))
-          ) : (
-            <div className='pl-2 hidden md:block'>{children}</div>
-          )}
+         {React.Children.toArray(children).map(child => (
+            <div className='pl-2 hidden md:block' key={child.key}>
+              {child}
+            </div>
+          ))}
           <div className='pl-2'>
             <AuthButton></AuthButton>
           </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #177

<!-- Feel free to add any additional description of changes below this line -->

1. To fix the 'Encountered two children with the same key...' warning, we can utilize the React.Children.toArray to return the children opaque data structure as a flat array with keys assigned to each child. So I assigned child.key to the key prop.
[https://reactjs.org/docs/react-api.html#reactchildrentoarray](url)
<img width="370" alt="Screen Shot 2022-11-01 at 5 13 06 PM" src="https://user-images.githubusercontent.com/90477208/199388721-f3c8fd1c-707c-42b0-ae54-97dada5fa310.png">

2. As the syntax of map function,  map((element) => { /* … */ }) , the element is the current element being processed in the array. It would be better to use child to refer to an element in the children array. 

3. The warning  'validateDOMNesting(…)...' existed because if a &lt;div&gt; tag is inside  &lt;p&gt; tag the paragraph will be broken at the point. To fix the warning, I removed p tag around the child, which is a div. 
[https://www.w3docs.com/learn-html/html-div-tag.html](url)
<img width="677" alt="Screen Shot 2022-11-01 at 5 32 53 PM" src="https://user-images.githubusercontent.com/90477208/199390281-140e03ea-22ba-45a3-9798-c49de7675693.png">


4. While there is no difference in children’s style and all the children are flex items of the same parent. We may not need to render them under conditions.
