### PR TITLE
fix: Stop showing dashed names when creating a classroom

### DIFF
--- a/components/ClassInviteTable.js
+++ b/components/ClassInviteTable.js
@@ -302,7 +302,7 @@ export default function ClassInviteTable({
                           <MultiSelect
                             options={certificationNames.map(x => ({
                               value: x['value'],
-                              label: x['display_name']
+                              label: x['displayName']
                             }))}
                             value={selected}
                             onChange={setSelected}

--- a/components/ClassInviteTable.js
+++ b/components/ClassInviteTable.js
@@ -300,7 +300,10 @@ export default function ClassInviteTable({
                             Edit Select Certifications:
                           </h1>
                           <MultiSelect
-                            options={certificationNames}
+                            options={certificationNames.map(x => ({
+                              value: x['value'],
+                              label: x['display_name']
+                            }))}
                             value={selected}
                             onChange={setSelected}
                             labelledBy='Select'

--- a/components/modal.js
+++ b/components/modal.js
@@ -103,7 +103,10 @@ export default function Modal({ userId, certificationNames }) {
                         <h1 className='text-white'>Select Certifications:</h1>
                         <MultiSelect
                           hidePlaceholder={false}
-                          options={certificationNames}
+                          options={certificationNames.map(x => ({
+                            value: x['value'],
+                            label: x['display_name']
+                          }))}
                           value={selected}
                           onChange={setSelected}
                           labelledBy='Select'

--- a/components/modal.js
+++ b/components/modal.js
@@ -105,7 +105,7 @@ export default function Modal({ userId, certificationNames }) {
                           hidePlaceholder={false}
                           options={certificationNames.map(x => ({
                             value: x['value'],
-                            label: x['display_name']
+                            label: x['displayName']
                           }))}
                           value={selected}
                           onChange={setSelected}

--- a/pages/classes/index.js
+++ b/pages/classes/index.js
@@ -58,7 +58,7 @@ export async function getServerSideProps(ctx) {
   const superblocksreq = await superblocksres.json();
   const blocks = [];
   superblocksreq['superblocks'].map((x, i) =>
-    blocks.push({ value: i, label: x.dashedName })
+    blocks.push({ value: i, label: x.title })
   );
   return {
     props: {

--- a/pages/classes/index.js
+++ b/pages/classes/index.js
@@ -58,7 +58,7 @@ export async function getServerSideProps(ctx) {
   const superblocksreq = await superblocksres.json();
   const blocks = [];
   superblocksreq['superblocks'].map((x, i) =>
-    blocks.push({ value: i, label: x.dashedName, display_name: x.title })
+    blocks.push({ value: i, label: x.dashedName, displayName: x.title })
   );
   return {
     props: {

--- a/pages/classes/index.js
+++ b/pages/classes/index.js
@@ -58,7 +58,7 @@ export async function getServerSideProps(ctx) {
   const superblocksreq = await superblocksres.json();
   const blocks = [];
   superblocksreq['superblocks'].map((x, i) =>
-    blocks.push({ value: i, label: x.title })
+    blocks.push({ value: i, label: x.dashedName, display_name: x.title })
   );
   return {
     props: {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #167
Co-authored by: Michelle Tan <michelle0223@gmail.com>
Co-authored by: Fadi Buni <fadibuni1@gmail.com>

Changed the title of the classes in the menu to title case format with no dashes.

Before:
![PR Dashes](https://user-images.githubusercontent.com/94425320/201541780-960ee52f-b537-47e2-9969-47fb079f1328.jpg)


After:
<!-- Feel free to add any additional description of changes below this line -->
![PR Non-Dashes](https://user-images.githubusercontent.com/94425320/201541771-cbf0184d-b651-48dc-801a-4466e44db19c.jpg)
