### PR TITLE
fix: dropdown menu display on small screens

### DIFF
--- a/components/ClassInviteTable.js
+++ b/components/ClassInviteTable.js
@@ -246,7 +246,7 @@ export default function ClassInviteTable({
             <>
               <div className='bg-zinc-200 opacity-100 fixed inset-0 z-50'>
                 <div className='flex h-screen justify-center items-center'>
-                  <div className='flex-col justify-center bg-[#0a0a23] py-12 px-24 border-4 border-sky-500 rounded-xl '>
+                  <div className='flex-col justify-center bg-[#0a0a23] py-12 px-24 border-4 border-sky-500 rounded-xl overflow-auto max-h-screen'>
                     <div className='flex text-lg text-white justify-center items-center'>
                       Edit Class
                     </div>

--- a/components/modal.js
+++ b/components/modal.js
@@ -48,7 +48,7 @@ export default function Modal({ userId, certificationNames }) {
           <>
             <div className='bg-zinc-200 opacity-100 fixed inset-0 z-50'>
               <div className='flex h-screen justify-center items-center'>
-                <div className='flex-col justify-center bg-[#0a0a23] py-12 px-24 border-4 border-sky-500 rounded-xl '>
+                <div className='flex-col justify-center bg-[#0a0a23] py-12 px-24 border-4 border-sky-500 rounded-xl overflow-auto max-h-screen'>
                   <div className='flex text-lg text-white justify-center items-center'>
                     Create Class
                   </div>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #184 

<!-- Feel free to add any additional description of changes below this line -->

Contributors:
Co-authored by: Michelle Tan <[michelle0223@gmail.com](mailto:michelle0223@gmail.com)>
Co-authored by: Fadi Buni <[fadibuni1@gmail.com](mailto:fadibuni1@gmail.com)>

Before:
![image](https://user-images.githubusercontent.com/94425320/204107096-a5fdf334-1757-4fa9-b0d6-1e3e5de11d58.png)

After:
![image](https://user-images.githubusercontent.com/94425320/204107075-0670d3f7-a637-4cbd-9c42-438dc166798f.png)

Summary:
We edited a css property in the div tags for the modal where we used "overflow-auto" and "max-h-screen" to allow the user to scroll when the menu fills the screen.