### PR TITLE
Force usage of Node 16 for GitPod development 

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,8 +10,8 @@ ports:
 tasks:
   - init: >
       cp .env.sample .env &&
-      npm install n -g && 
-      n 16 &&
+      nvm install 16.20.0 && 
+      nvm alias default 16.20.0 &&
       npm ci --no-audit --no-progress &&
       npx prisma generate &&
       npx prisma db push &&

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,7 +10,7 @@ ports:
 tasks:
   - init: >
       cp .env.sample .env &&
-      nvm install 16.20.0 && 
+      nvm install 16.20.0 &&
       nvm alias default 16.20.0 &&
       npm ci --no-audit --no-progress &&
       npx prisma generate &&

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,8 @@ ports:
 tasks:
   - init: >
       cp .env.sample .env &&
+      npm install n -g && 
+      n 16 &&
       npm ci --no-audit --no-progress &&
       npx prisma generate &&
       npx prisma db push &&


### PR DESCRIPTION
Earlier, we faced an issue where GitPod would force users to run Node 18, we assume this was an issue on their end since they typically run Node v16.8.1

Now, we're simply error-proofing this for contributors so that they can use Node 16 no matter what version of Node Gitpod runs. 