### PR TITLE
docs: added missing command to start prisma studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ postgresql://postgres:password@localhost:5432/classroom
 8. Run `npm run mock-fcc-data`
 9. Run `npx prisma studio`
 
+Need more help? Ran into issues? Check out this [guide](https://docs.google.com/document/d/1apfjzfIwDAfg6QQf2KD1E1aeD-KU7DEllwnH9Levq4A/edit) that walks you through all the steps of setting up the repository locally, without Docker.
+
 ### Join us in our [Discord Chat](https://discord.gg/qcynkd4Edx) here.
 
 ### License

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a while now teachers have been asking for a way to get a birds eye view of m
 
 ### Optional - GitPod Dev Environment
 
-If you want a ready made dev environment in your browser, make a fork of this repository and then prefix your fork with "gitpod.io/#".  For example, 
+If you want a ready made dev environment in your browser, make a fork of this repository and then prefix your fork with "gitpod.io/#". For example,
 `gitpod.io/#https://github.com/{your-github-user-name}/classroom`
 You will still need to setup your NextAuth related environment variables in the .env file.
 For more information, please follow the "Setup Instructions" in the terminal.
@@ -67,6 +67,7 @@ postgresql://postgres:password@localhost:5432/classroom
 6. Run `npx prisma db seed`.
 7. Run `npm run develop`.
 8. Run `npm run mock-fcc-data`
+9. Run `npx prisma studio`
 
 ### Join us in our [Discord Chat](https://discord.gg/qcynkd4Edx) here.
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [X] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [X] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

This update does not close any issue. Lloyd Chang (CodeLabs Mentor) proposed that I should update this section of the documentation. It gave me a delay of 2 days trying to figure out why the Prisma Studio was not up and running, and this command was documented in the [gitpod set up instructions file](https://github.com/freeCodeCamp/classroom/blob/main/gitpod-instructions.sh). However,  I am using local set up with docker. This command immediately fixed the issue and I was able to view Prisma Studio. This command belongs under the local set up instructions as well. 
