### PR TITLE
fix: Fixing invalid identifier inside of CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: Classroom ci
 on: [push, pull_request]
 
 jobs:
-  build and test:
+  build-and-test:
     name: Build and test
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Fixed invalid identifier from ('build and test') to ('build-and-test')

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #363 

<!-- Feel free to add any additional description of changes below this line -->
