### PR TITLE
Fixed Codespace env URLs to match the GitHub Codespaces change. GitHu…

### DIFF
--- a/codespace-instructions.sh
+++ b/codespace-instructions.sh
@@ -8,15 +8,15 @@ echo 1.\) For dev environments, we have enabled use of the Github Provider. Plea
 echo https://docs.github.com/en/developers/apps/building-oauth-apps/creating-an-oauth-app
 echo
 echo The mock user data URL is:   
-echo https://${CODESPACE_NAME}-3001.preview.app.github.dev/data
+echo https://${CODESPACE_NAME}-3001.app.github.dev/data
 echo
 echo The homepage is:   
-echo https://${CODESPACE_NAME}-3000.preview.app.github.dev
+echo https://${CODESPACE_NAME}-3000.app.github.dev
 echo 
 echo The callback url is:
-echo https://${CODESPACE_NAME}-3000.preview.app.github.dev/api/auth/callback/github
+echo https://${CODESPACE_NAME}-3000.app.github.dev/api/auth/callback/github
 echo
-echo 2.\) Set NEXTAUTH_URL in .env to https://${CODESPACE_NAME}-3000.preview.app.github.dev
+echo 2.\) Set NEXTAUTH_URL in .env to https://${CODESPACE_NAME}-3000.app.github.dev
 echo
 echo 3.\) To setup GITHUB_ID and GITHUB_SECRET after setting up the OAuth app: 
 echo      -Your Client ID is shown in the OAuth app page. Copy and paste to GITHUB_ID. 


### PR DESCRIPTION
…b no longer includes the 'preview' text in the public URL.

Co-authored-by: Utsab Saha <utsab.k.saha@gmail.com>

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!-- Feel free to add any additional description of changes below this line -->
GitHub suddenly decided to change the format for the Codespace URLs; the 'preview' text is no longer present in the URL. This PR updates the auto-generated URLs to match the new format. 