### PR TITLE
fix: Only parse response body as json when server returns 200 in modal.

### DIFF
--- a/components/modal.js
+++ b/components/modal.js
@@ -38,8 +38,8 @@ export default function Modal({
       body: JSON.stringify(formData)
     });
 
-    const jsonRes = await response.json();
-    if (response.status === 200) {
+    if (response.ok) {
+      let jsonRes = await response.json()
       let newClassroom = {
         classroomName: jsonRes.classroomName,
         description: jsonRes.description,


### PR DESCRIPTION
Set up this project once again and went to create a class, I found some runtime error. It was because we were parsing json on a non 200 response from the API. Before/After pics included. 

The reason why I was getting 403 was because my database was set up wrong so unlikely this error would show up in production, still better to handle errors properly on client side for any other kinds of errors (like 500 due to timeout).

![Screenshot 2023-10-29 at 5 22 49 PM](https://github.com/freeCodeCamp/classroom/assets/37780741/07355c58-69ce-4fe3-8edc-cc803bb47b92)

![Screenshot 2023-10-29 at 5 36 23 PM](https://github.com/freeCodeCamp/classroom/assets/37780741/23fce328-2448-4824-ada1-a9b47bdc26d4)


Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
