### PR TITLE
fix: Updated href attribute in dashboard_V2 component to only use interpolation.

### DIFF
--- a/components/dashtable_v2.js
+++ b/components/dashtable_v2.js
@@ -43,7 +43,7 @@ export default function GlobalDashboardTable(props) {
       detail: (
         <a
           // TODO:
-          href={`/dashboard/v2/details/${props.classroomId}/` + `${email}`}
+          href={`/dashboard/v2/details/${props.classroomId}/${email}`}
         >
           {' '}
           details{' '}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Hello. I am a student at Oregon State University and I am attempting some of my first contributions to an open source project.
If this task was being held for anyone else, feel free to reject. 
- Updated href attribute to use only string interpolation instead of interpolation and concatenation. 