### PR TITLE
Fix: Redirect to home page after sign out (Issue #538)

### DIFF
--- a/components/authButton.js
+++ b/components/authButton.js
@@ -6,7 +6,7 @@ export default function AuthButton() {
     return (
       <>
         <button
-          onClick={() => signOut()}
+          onClick={() => signOut({ callbackUrl: '/' })}
           className='hover:bg-[#ffbf00] shadow-lg border-solid border-color: inherit; border-[1px] pl-4 pr-4 bg-fcc-primary-yellow text-black'
         >
           Sign out


### PR DESCRIPTION
This PR addresses Issue #538 by ensuring users are redirected to the home page after signing out.

Changes made:
- Added `callbackUrl: '/'` to the `signOut` function to fix the bug where users were being redirected to the error page after logging out from a non-main page.
- This improves the user experience by guiding users back to the appropriate landing page post sign out.

Tested and confirmed the behavior works as expected.

Closes #538.
