### PR TITLE
fix: require certification before creating class

### DIFF
--- a/__tests__/components/__snapshots__/modal.test.jsx.snap
+++ b/__tests__/components/__snapshots__/modal.test.jsx.snap
@@ -169,7 +169,9 @@ exports[`Modal Component renders whole form after header clicked 1`] = `
             className="flex items-center justify-center"
           >
             <button
-              className=" rounded px-4 py-2 text-white bg-green-700"
+              className="rounded px-4 py-2 text-white bg-green-700 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={true}
+              title="Please select a certification."
               type="submit"
             >
               Create

--- a/__tests__/components/modal.test.jsx
+++ b/__tests__/components/modal.test.jsx
@@ -53,4 +53,19 @@ describe('Modal Component', () => {
     const tree = testRenderer.toJSON();
     expect(tree).toMatchSnapshot();
   });
+  it('disables the create button until a certification is selected', () => {
+    const testRenderer = renderer.create(
+      <Modal userId={sampleUser} certificationNames={sampleData} />
+    );
+    const testInstance = testRenderer.root;
+    const header = testInstance.findByProps({ className });
+
+    act(() => {
+      header.props.onClick();
+    });
+
+    const createButton = testInstance.findAllByType('button')[0];
+    expect(createButton.props.disabled).toBe(true);
+    expect(createButton.props.title).toBe('Please select a certification.');
+  });
 });

--- a/components/modal.js
+++ b/components/modal.js
@@ -151,7 +151,13 @@ export default function Modal({
                     <div className='flex items-center justify-center'>
                       <button
                         type='submit'
-                        className=' rounded px-4 py-2 text-white bg-green-700'
+                        className='rounded px-4 py-2 text-white bg-green-700 disabled:cursor-not-allowed disabled:opacity-50'
+                        disabled={selected.length === 0}
+                        title={
+                          selected.length === 0
+                            ? 'Please select a certification.'
+                            : undefined
+                        }
                       >
                         Create
                       </button>


### PR DESCRIPTION
## Summary
- disable the Create button until a certification is selected
- show guidance explaining that a certification is required
- add a regression test for the disabled state

## Testing
- `npm test -- --runInBand`
- `npm run lint:code`
- `npx prettier --check components/modal.js __tests__/components/modal.test.jsx`

Closes #551