### PR TITLE
fix(navbar): point home button to root route

### DIFF
--- a/__tests__/components/__snapshots__/error.test.jsx.snap
+++ b/__tests__/components/__snapshots__/error.test.jsx.snap
@@ -13,7 +13,7 @@ exports[`ErrorComponet displays error cause and error message properly 1`] = `
       />
       <a
         className="flex items-center"
-        href="/classes"
+        href="/"
         onClick={[Function]}
         onMouseEnter={[Function]}
         onTouchStart={[Function]}

--- a/__tests__/components/__snapshots__/navbar.test.jsx.snap
+++ b/__tests__/components/__snapshots__/navbar.test.jsx.snap
@@ -12,7 +12,7 @@ exports[`Navbar rendering correctly renders correctly 1`] = `
     />
     <a
       className="flex items-center"
-      href="/classes"
+      href="/"
       onClick={[Function]}
       onMouseEnter={[Function]}
       onTouchStart={[Function]}

--- a/__tests__/components/navbar.test.jsx
+++ b/__tests__/components/navbar.test.jsx
@@ -1,6 +1,8 @@
 import Navbar from '../../components/navbar';
 import React from 'react';
 import { SessionProvider } from 'next-auth/react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
 import renderer from 'react-test-renderer';
 
 describe('Navbar rendering correctly', () => {
@@ -13,5 +15,45 @@ describe('Navbar rendering correctly', () => {
       )
       .toJSON();
     expect(tree).toMatchSnapshot();
+  });
+});
+
+describe('Navbar Home button', () => {
+  const findHomeLink = () => screen.getByRole('link', { name: /freecodecamp logo/i });
+
+  it('points to the application home page when logged in as a teacher', () => {
+    render(
+      <SessionProvider session={{ user: { name: 'teacher', role: 'TEACHER' } }}>
+        <Navbar />
+      </SessionProvider>
+    );
+    expect(findHomeLink()).toHaveAttribute('href', '/');
+  });
+
+  it('points to the application home page when logged in as an admin', () => {
+    render(
+      <SessionProvider session={{ user: { name: 'admin', role: 'ADMIN' } }}>
+        <Navbar />
+      </SessionProvider>
+    );
+    expect(findHomeLink()).toHaveAttribute('href', '/');
+  });
+
+  it('points to the application home page when logged in as another role', () => {
+    render(
+      <SessionProvider session={{ user: { name: 'student', role: 'STUDENT' } }}>
+        <Navbar />
+      </SessionProvider>
+    );
+    expect(findHomeLink()).toHaveAttribute('href', '/');
+  });
+
+  it('points to the application home page when not logged in', () => {
+    render(
+      <SessionProvider session={null}>
+        <Navbar />
+      </SessionProvider>
+    );
+    expect(findHomeLink()).toHaveAttribute('href', '/');
   });
 });

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -8,7 +8,7 @@ export default function Navbar({ children, hideAuthButton = false }) {
     <div className='h-[38px]'>
       <div className='h-[38px] bg-fcc-gray-90 text-white flex items-center flex-wrap p-1'>
         <div className='hidden lg:flex block flex-1 justify-end'></div>
-        <Link href='/classes' className='flex items-center'>
+        <Link href='/' className='flex items-center'>
           <Image
             className=''
             priority


### PR DESCRIPTION
The Navbar Home button (the FCC logo link) was hard-coded to /classes, which is a teacher-only route. As a result, admins, students, and unauthenticated users were redirected to the error page when they clicked the site logo.

This change makes the Home button point to /, the application's actual home page (pages/index.js), regardless of role or auth state, and brings it in line with the other "Menu" links in the codebase.

Fixes #558

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
